### PR TITLE
Update QG Analysis to use MetPy 0.10 features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ env:
     - Python: 3.5
     - Python: 3.6
     - Python: 3.7
-    - Python: 3.7
-      env: TASK="dev"
+    - Python: 3.7 TASK="dev"
 
 before_install:
   # Taken from: http://conda.pydata.org/docs/travis.html
@@ -44,9 +43,9 @@ install:
   - source activate unidata
   - if [[ $TASK == "dev" ]]; then
       conda uninstall metpy;
-      pip install https://github.com/unidata/metpy;
+      pip install git+git://github.com/unidata/metpy.git;
       conda uninstall siphon;
-      pip install https://github.com/unidata/siphon;
+      pip install git+git://github.com/unidata/siphon.git;
     fi;
   - python --version
   - conda list

--- a/notebooks/MetPy_Advanced/QG Analysis.ipynb
+++ b/notebooks/MetPy_Advanced/QG Analysis.ipynb
@@ -146,7 +146,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataset(xr.backends.NetCDF4DataStore(data))\n",
+    "# Open data with xarray, and parse it with MetPy\n",
+    "ds = xr.open_dataset(xr.backends.NetCDF4DataStore(data)).metpy.parse_cf()\n",
     "ds"
    ]
   },
@@ -158,7 +159,7 @@
    "source": [
     "# Back up in case of bad internet connection.\n",
     "# Uncomment the following line to read local netCDF file of NARR data\n",
-    "# ds = xr.open_dataset('../../data/NARR_19930313_0000.nc')"
+    "# ds = xr.open_dataset('../../data/NARR_19930313_0000.nc').metpy.parse_cf()"
    ]
   },
   {
@@ -166,7 +167,7 @@
    "metadata": {},
    "source": [
     "### Subset Pressure Levels\n",
-    "Using xarray gives great funtionality for selecting pieces of your dataset to use within your script/program."
+    "Using xarray gives great funtionality for selecting pieces of your dataset to use within your script/program. MetPy also includes helpers for unit- and coordinate-aware selection and getting unit arrays from xarray DataArrays."
    ]
   },
   {
@@ -175,47 +176,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Helper code to determine names of time and vertical level dimensions\n",
-    "# Due to grib these two variables names change frequently\n",
-    "dim_names = ds.Geopotential_height_isobaric.dims\n",
-    "lev_name = [v for v in dim_names if v.startswith('isobaric')][0]\n",
-    "time_name = [v for v in dim_names if v.startswith('time')][0]\n",
-    "\n",
     "# Save time of data to datetime format\n",
-    "vtime = datetime.strptime(str(ds[time_name].sel({time_name:'{:%Y-%m-%d}'.format(dt)}).values.astype('datetime64[ms]')),\n",
-    "                          '%Y-%m-%dT%H:%M:%S.%f')\n",
-    "# Grab lat/lon values from file\n",
-    "lats = ds.lat.values\n",
-    "lons = ds.lon.values\n",
+    "time_format = '%Y-%m-%dT%H:%M:%S.%f'\n",
+    "vtime = datetime.strptime(ds.Temperature_isobaric.metpy.time.dt.strftime(time_format)[0],\n",
+    "                          time_format)\n",
+    "\n",
+    "# Grab lat/lon values from file as unit arrays\n",
+    "lats = ds.lat.metpy.unit_array\n",
+    "lons = ds.lon.metpy.unit_array\n",
     "\n",
     "# Calculate distance between grid points\n",
     "# will need for computations later\n",
     "dx, dy = mpcalc.lat_lon_grid_deltas(lons, lats)\n",
     "\n",
-    "# Grabbing data for specific variable contained in file\n",
+    "# Grabbing data for specific variable contained in file (as a unit array)\n",
     "# 700 hPa Geopotential Heights\n",
-    "hght_700 = (ds.Geopotential_height_isobaric.sel({lev_name:700, time_name:'{:%Y-%m-%d}'.format(dt)}).values\n",
-    "            * units(ds.Geopotential_height_isobaric.units))\n",
+    "hght_700 = ds.Geopotential_height_isobaric.metpy.sel(vertical=700 * units.hPa,\n",
+    "                                                     time=vtime).metpy.unit_array\n",
     "\n",
     "# Equivalent form needed if there is a dash in name of variable\n",
     "# (e.g., 'u-component_of_wind_isobaric')\n",
-    "# hght_700 = ds['Geopotential_height_isobaric'].sel({lev_name:700, time_name:'{:%Y-%m-%d}'.format(dt)}).values \\\n",
-    "#                                                  * units(ds.Geopotential_height_isobaric.units)\n",
+    "# hght_700 = ds['Geopotential_height_isobaric'].metpy.sel(vertical=700 * units.hPa, time=vtime).metpy.unit_array\n",
     "\n",
     "# 700 hPa Temperature\n",
-    "tmpk_700 = (ds.Temperature_isobaric.sel({lev_name:700,\n",
-    "                                        time_name:'{:%Y-%m-%d}'.format(dt)}).values\n",
-    "            * units(ds.Temperature_isobaric.units))\n",
+    "tmpk_700 = ds.Temperature_isobaric.metpy.sel(vertical=700 * units.hPa,\n",
+    "                                             time=vtime).metpy.unit_array\n",
     "\n",
     "# 700 hPa u-component_of_wind\n",
-    "uwnd_700 = (ds['u-component_of_wind_isobaric'].sel({lev_name:700,\n",
-    "                                                   time_name:'{:%Y-%m-%d}'.format(dt)}).values\n",
-    "            * units(ds['u-component_of_wind_isobaric'].units))\n",
+    "uwnd_700 = ds['u-component_of_wind_isobaric'].metpy.sel(vertical=700 * units.hPa,\n",
+    "                                                        time=vtime).metpy.unit_array\n",
     "\n",
     "# 700 hPa v-component_of_wind\n",
-    "vwnd_700 = (ds['v-component_of_wind_isobaric'].sel({lev_name:700,\n",
-    "                                                   time_name:'{:%Y-%m-%d}'.format(dt)}).values\n",
-    "            * units(ds['v-component_of_wind_isobaric'].units))"
+    "vwnd_700 = ds['v-component_of_wind_isobaric'].metpy.sel(vertical=700 * units.hPa,\n",
+    "                                                        time=vtime).metpy.unit_array"
    ]
   },
   {
@@ -316,35 +309,24 @@
     "# a little to get to the \"synoptic values\" from higher\n",
     "# resolution datasets\n",
     "\n",
-    "# Helper function to do a nine point smoothing\n",
-    "# with posibility for repetition of smoothing\n",
-    "# in order to smooth more.\n",
-    "def smooth_9_points(S, reps=1):\n",
-    "    sm9s = S[:].copy()\n",
-    "    for i in range(reps):\n",
-    "        sm9s[1:-1,1:-1] = 0.25*sm9s[1:-1,1:-1] + \\\n",
-    "                          0.125*(sm9s[2:,1:-1] + sm9s[1:-1,2:] + sm9s[:-2,1:-1] + sm9s[1:-1,:-2]) + \\\n",
-    "                          0.0625*(sm9s[2:,2:] + sm9s[2:,:-2] + sm9s[:-2,2:] + sm9s[:-2,:-2])\n",
-    "    return sm9s\n",
-    "\n",
     "# Number of repetitions of smoothing function\n",
     "n_reps = 50\n",
     "\n",
-    "hght_700s = smooth_9_points(hght_700, n_reps)\n",
-    "hght_500s = smooth_9_points(hght_500, n_reps)\n",
+    "# Apply the 9-point smoother\n",
+    "hght_700s = mpcalc.smooth_n_point(hght_700, 9, n_reps)\n",
+    "hght_500s = mpcalc.smooth_n_point(hght_500, 9, n_reps)\n",
     "\n",
-    "tmpk_700s = smooth_9_points(tmpk_700, n_reps)\n",
+    "tmpk_700s = mpcalc.smooth_n_point(tmpk_700, 9, n_reps)\n",
     "tmpc_700s = tmpk_700s.to('degC')\n",
     "\n",
-    "uwnd_700s = smooth_9_points(uwnd_700, n_reps)\n",
-    "vwnd_700s = smooth_9_points(vwnd_700, n_reps)\n",
+    "uwnd_700s = mpcalc.smooth_n_point(uwnd_700, 9, n_reps)\n",
+    "vwnd_700s = mpcalc.smooth_n_point(vwnd_700, 9, n_reps)\n",
     "\n",
-    "uwnd_500s = smooth_9_points(uwnd_500, n_reps)\n",
-    "vwnd_500s = smooth_9_points(vwnd_500, n_reps)\n",
+    "uwnd_500s = mpcalc.smooth_n_point(uwnd_500, 9, n_reps)\n",
+    "vwnd_500s = mpcalc.smooth_n_point(vwnd_500, 9, n_reps)\n",
     "\n",
-    "uwnd_900s = smooth_9_points(uwnd_900, n_reps)\n",
-    "vwnd_900s = smooth_9_points(vwnd_900, n_reps)\n",
-    "    \n"
+    "uwnd_900s = mpcalc.smooth_n_point(uwnd_900, 9, n_reps)\n",
+    "vwnd_900s = mpcalc.smooth_n_point(vwnd_900, 9, n_reps)"
    ]
   },
   {
@@ -368,9 +350,9 @@
    "source": [
     "# Absolute Vorticity Calculation\n",
     "avor_900 = mpcalc.absolute_vorticity(uwnd_900s, vwnd_900s, dx, dy,\n",
-    "                                     lats * units('degrees'), dim_order='yx')\n",
+    "                                     lats, dim_order='yx')\n",
     "avor_500 = mpcalc.absolute_vorticity(uwnd_500s, vwnd_500s, dx, dy,\n",
-    "                                     lats * units('degrees'), dim_order='yx')\n",
+    "                                     lats, dim_order='yx')\n",
     "\n",
     "# Advection of Absolute Vorticity\n",
     "vortadv_900 = mpcalc.advection(avor_900, (uwnd_900s, vwnd_900s), (dx, dy),\n",
@@ -524,7 +506,7 @@
     "plt.colorbar(cf, orientation='horizontal', pad=0.0, aspect=50, extendrect=True)\n",
     "\n",
     "# Vector\n",
-    "ax.barbs(lons, lats, uwnd_700.to('kts').m, vwnd_700.to('kts').m,\n",
+    "ax.barbs(lons.m, lats.m, uwnd_700.to('kts').m, vwnd_700.to('kts').m,\n",
     "         regrid_shape=15, transform=dataproj)\n",
     "\n",
     "# Titles\n",
@@ -559,7 +541,7 @@
     "plt.colorbar(cf, orientation='horizontal', pad=0.0, aspect=50, extendrect=True)\n",
     "\n",
     "# Vector\n",
-    "ax.barbs(lons, lats, uwnd_500.to('kts').m, vwnd_500.to('kts').m,\n",
+    "ax.barbs(lons.m, lats.m, uwnd_500.to('kts').m, vwnd_500.to('kts').m,\n",
     "         regrid_shape=15, transform=dataproj)\n",
     "\n",
     "# Titles\n",
@@ -593,7 +575,7 @@
     "plt.colorbar(cf, orientation='horizontal', pad=0.0, aspect=50, extendrect=True)\n",
     "\n",
     "# Vector\n",
-    "ax.barbs(lons, lats, uwnd_700s.to('kts').m, vwnd_700s.to('kts').m,\n",
+    "ax.barbs(lons.m, lats.m, uwnd_700s.to('kts').m, vwnd_700s.to('kts').m,\n",
     "         regrid_shape=15, transform=dataproj)\n",
     "\n",
     "# Titles\n",
@@ -627,7 +609,7 @@
     "plt.colorbar(cf, orientation='horizontal', pad=0.0, aspect=50, extendrect=True)\n",
     "\n",
     "# Vector\n",
-    "ax.barbs(lons, lats, uwnd_500s.to('kt').m, vwnd_500s.to('kt').m,\n",
+    "ax.barbs(lons.m, lats.m, uwnd_500s.to('kt').m, vwnd_500s.to('kt').m,\n",
     "         regrid_shape=15, transform=dataproj)\n",
     "\n",
     "# Titles\n",
@@ -671,13 +653,6 @@
    "source": [
     "# %load solutions/qg_omega_total_fig.py\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -696,7 +671,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/MetPy_Advanced/solutions/QG_data.py
+++ b/notebooks/MetPy_Advanced/solutions/QG_data.py
@@ -1,16 +1,11 @@
 # Remaining variables needed to compute QG Omega forcing terms
-hght_500 = (ds.Geopotential_height_isobaric.sel({lev_name:500,
-                                                time_name:'{:%Y-%m-%d}'.format(dt)}).values
-            * units(ds.Geopotential_height_isobaric.units))
-uwnd_500 = (ds['u-component_of_wind_isobaric'].sel({lev_name:500,
-                                                   time_name:'{:%Y-%m-%d}'.format(dt)}).values
-            * units(ds['u-component_of_wind_isobaric'].units))
-vwnd_500 = (ds['v-component_of_wind_isobaric'].sel({lev_name:500,
-                                                   time_name:'{:%Y-%m-%d}'.format(dt)}).values
-            * units(ds['v-component_of_wind_isobaric'].units))
-uwnd_900 = (ds['u-component_of_wind_isobaric'].sel({lev_name:900,
-                                                   time_name:'{:%Y-%m-%d}'.format(dt)}).values
-            * units(ds['u-component_of_wind_isobaric'].units))
-vwnd_900 = (ds['v-component_of_wind_isobaric'].sel({lev_name:900,
-                                                   time_name:'{:%Y-%m-%d}'.format(dt)}).values
-            * units(ds['v-component_of_wind_isobaric'].units))
+hght_500 = ds.Geopotential_height_isobaric.metpy.sel(vertical=500 * units.hPa,
+                                                     time=vtime).metpy.unit_array
+uwnd_500 = ds['u-component_of_wind_isobaric'].metpy.sel(vertical=500 * units.hPa,
+                                                        time=vtime).metpy.unit_array
+vwnd_500 = ds['v-component_of_wind_isobaric'].metpy.sel(vertical=500 * units.hPa,
+                                                        time=vtime).metpy.unit_array
+uwnd_900 = ds['u-component_of_wind_isobaric'].metpy.sel(vertical=900 * units.hPa,
+                                                        time=vtime).metpy.unit_array
+vwnd_900 = ds['v-component_of_wind_isobaric'].metpy.sel(vertical=900 * units.hPa,
+                                                        time=vtime).metpy.unit_array

--- a/notebooks/MetPy_Advanced/solutions/qg_omega_total_fig.py
+++ b/notebooks/MetPy_Advanced/solutions/qg_omega_total_fig.py
@@ -24,7 +24,7 @@ cf = ax.contourf(lons, lats, (term_A+term_B)*10**12, clev_omega,
 plt.colorbar(cf, orientation='horizontal', pad=0.0, aspect=50, extendrect=True)
 
 # Vector
-ax.barbs(lons, lats, uwnd_700s.to('kts').m, vwnd_700s.to('kts').m,
+ax.barbs(lons.m, lats.m, uwnd_700s.to('kts').m, vwnd_700s.to('kts').m,
          regrid_shape=15, transform=dataproj)
 
 # Titles


### PR DESCRIPTION
As discussed in the dev chat last Friday, this PR reworks the data selection in the QG Analysis notebook to utilize MetPy's xarray accessors. Also, it updates the smoother to use the n-point smoother that will be available in MetPy v0.10. Hopefully this makes it a little cleaner.

One other side point: as I was working through the notebook, I noticed that the plots are using the lats and lons from the data and re-projecting to a new Lambert Conformal projection, rather than plotting on NARR's Lambert Conformal grid. When I swapped over the last solution to use the native grid instead of re-projecting, it sped up the plotting from ~20 to ~3 seconds on my machine. Would it be worth changing the example and solution to use the native grid?