### PR TITLE
Fix satellite animation on Windows

### DIFF
--- a/notebooks/Satellite_Data/PlottingSatelliteData.ipynb
+++ b/notebooks/Satellite_Data/PlottingSatelliteData.ipynb
@@ -610,7 +610,7 @@
     "for ds in datasets[::-6]:\n",
     "\n",
     "    # Open the data\n",
-    "    ds = ds.remote_access(service='OPENDAP', use_xarray=True)\n",
+    "    ds = ds.remote_access(use_xarray=True)\n",
     "    dat = ds.metpy.parse_cf('Sectorized_CMI')\n",
     "    \n",
     "    # Pull out the image data, x and y coordinates, and the time. Also go ahead and\n",


### PR DESCRIPTION
Remove opendap default for Windows. Otherwise we get an OSError of trying to write to a read-only file.