### PR TITLE
Find identical levels for variables to fix GFS-FV3 update

### DIFF
--- a/notebooks/MetPy_Advanced/Isentropic Analysis.ipynb
+++ b/notebooks/MetPy_Advanced/Isentropic Analysis.ipynb
@@ -41,7 +41,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "from siphon.catalog import TDSCatalog\n",
@@ -61,7 +65,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "subset_access = best.subset()\n",
@@ -78,7 +86,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "sorted(v for v in subset_access.variables if v.endswith('isobaric'))"
@@ -94,7 +106,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
@@ -116,7 +132,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "nc = subset_access.get_data(query)"
@@ -132,7 +152,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "from xarray.backends import NetCDF4DataStore\n",
@@ -153,7 +177,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "import metpy.calc as mpcalc\n",
@@ -171,7 +199,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "dat = ds.metpy.parse_cf('Temperature_isobaric')"
@@ -180,7 +212,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "data_proj = dat.metpy.cartopy_crs"
@@ -196,7 +232,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "lat = dat.metpy.y\n",
@@ -210,24 +250,37 @@
     "rh = ds['Relative_humidity_isobaric'][0]\n",
     "height = ds['Geopotential_height_isobaric'][0]\n",
     "u = ds['u-component_of_wind_isobaric'][0]\n",
-    "v = ds['v-component_of_wind_isobaric'][0]"
+    "v = ds['v-component_of_wind_isobaric'][0]\n",
+    "\n",
+    "# Due to a different number of vertical levels find where they are common\n",
+    "lev_hght = temperature.coords['isobaric4'] * units.Pa\n",
+    "lev_uwnd = u.coords['isobaric'] * units.Pa\n",
+    "_, _, common_ind = np.intersect1d(lev_uwnd, lev_hght, return_indices=True)\n",
+    "temperature = temperature[common_ind, :, :]\n",
+    "# Reassign units to variables\n",
+    "temperature.attrs['units'] = 'kelvin'\n",
+    "lev_uwnd.attrs['units'] = 'Pa'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we perform the isentropic interpolation. At a minimum, this must be given one or more isentropic levels, the 3-D temperature field, and the pressure levels of the original field; it then returns the 3D array of pressure values (2D slices for each isentropic level). You can also pass addition fields which will be interpolated to these levels as well. Below, we interpolate the winds (and pressure) to the 295K isentropic level:"
+    "Next, we perform the isentropic interpolation. At a minimum, this must be given one or more isentropic levels, the 3-D temperature field, and the pressure levels of the original field; it then returns the 3D array of pressure values (2D slices for each isentropic level). You can also pass addition fields which will be interpolated to these levels as well. Below, we interpolate the winds (and pressure) to the 320K isentropic level:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "isen_level = np.array([320]) * units.kelvin\n",
-    "isen_press, isen_u, isen_v = mpcalc.isentropic_interpolation(isen_level, press,\n",
+    "isen_press, isen_u, isen_v = mpcalc.isentropic_interpolation(isen_level, lev_uwnd,\n",
     "                                                             temperature, u, v)"
    ]
   },
@@ -241,7 +294,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "# Need to squeeze() out the size-1 dimension for the isentropic level\n",
@@ -253,7 +310,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -508,7 +569,16 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/MetPy_Case_Study/MetPy_Case_Study.ipynb
+++ b/notebooks/MetPy_Case_Study/MetPy_Case_Study.ipynb
@@ -253,7 +253,7 @@
     "\n",
     "# Extract coordinate data for plotting\n",
     "lat = data.variables['lat'][:]\n",
-    "lon = 0\n",
+    "lon = data.variables['lon'][:]\n",
     "lev = 0"
    ]
   },
@@ -313,7 +313,7 @@
    "outputs": [],
    "source": [
     "# Calcualte dx and dy for calculations\n",
-    "dx, dy = mpcalc.lat_lon_grid_spacing(lon, lat)"
+    "dx, dy = mpcalc.lat_lon_grid_deltas(lon, lat)"
    ]
   },
   {
@@ -1278,7 +1278,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/Model_Output/Downloading model fields with NCSS.ipynb
+++ b/notebooks/Model_Output/Downloading model fields with NCSS.ipynb
@@ -49,7 +49,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "# Resolve the latest GFS dataset\n",
@@ -74,6 +78,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "pycharm": {
+     "is_executing": false
+    },
     "scrolled": false
    },
    "outputs": [],
@@ -91,7 +98,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "from datetime import datetime, timedelta\n",
@@ -138,7 +149,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "data"
@@ -154,7 +169,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "from xarray.backends import NetCDF4DataStore\n",
@@ -167,7 +186,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "var = ds.metpy.parse_cf('Temperature_isobaric')\n",
@@ -184,7 +207,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "latitude = var.metpy.y\n",
@@ -210,7 +237,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -363,6 +394,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "pycharm": {
+     "is_executing": false
+    },
     "scrolled": true
    },
    "outputs": [],
@@ -392,13 +426,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "from metpy.units import units\n",
+    "import numpy as np\n",
     "\n",
     "# get netCDF variables\n",
     "pressure = point_data.variables[\"isobaric\"]\n",
+    "lev_temp = point_data.variables[\"isobaric4\"]\n",
     "temp = point_data.variables[\"Temperature_isobaric\"]\n",
     "u_cmp = point_data.variables[\"u-component_of_wind_isobaric\"]\n",
     "v_cmp = point_data.variables[\"v-component_of_wind_isobaric\"]\n",
@@ -410,7 +450,11 @@
     "T = units(temp.units) * temp[:].squeeze()\n",
     "u = units(u_cmp.units) * u_cmp[:].squeeze()\n",
     "v = units(v_cmp.units) * v_cmp[:].squeeze()\n",
-    "relh = units('percent') * relh[:].squeeze()"
+    "relh = units('percent') * relh[:].squeeze()\n",
+    "\n",
+    "# Due to a different number of vertical levels find where they are common\n",
+    "_, _, common_ind = np.intersect1d(pressure, lev_temp, return_indices=True)\n",
+    "T = T[common_ind]"
    ]
   },
   {
@@ -424,6 +468,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "pycharm": {
+     "is_executing": false
+    },
     "scrolled": true
    },
    "outputs": [],
@@ -443,7 +490,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "p.ito(units.millibar)\n",
@@ -456,7 +507,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "from metpy.plots import SkewT\n",
@@ -497,7 +552,16 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.3"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update to the Isentropic Analysis and NCSS notebooks to find identical vertical levels between temperature and other variables due to the differing number of vertical levels caused by the FV3 update to the GFS.

Fixes #422.