### PR TITLE
Updated thredds links for satellite notebooks

### DIFF
--- a/notebooks/Satellite_Data/GOES_Interactive_Plot.ipynb
+++ b/notebooks/Satellite_Data/GOES_Interactive_Plot.ipynb
@@ -24,7 +24,6 @@
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
-    "\n",
     "import cartopy.crs as ccrs\n",
     "import cartopy.feature as cfeature\n",
     "from IPython.display import display\n",
@@ -48,8 +47,8 @@
     "    Open and return a netCDF Dataset object for a given date, channel, and image index\n",
     "    of GOES-16 data from THREDDS test server.\n",
     "    \"\"\"\n",
-    "    cat = TDSCatalog('http://thredds.ucar.edu/thredds/catalog/satellite/goes16/GOES16/'\n",
-    "                     f'{region}/Channel{channel:02d}/{date:%Y%m%d}/catalog.xml')\n",
+    "    cat = TDSCatalog('https://thredds.ucar.edu/thredds/catalog/satellite/goes/east/products/'\n",
+    "                     f'CloudAndMoistureImagery/{region}/Channel{channel:02d}/{date:%Y%m%d}/catalog.xml')\n",
     "    ds = cat.datasets[idx]\n",
     "    ds = ds.remote_access(use_xarray=True)   \n",
     "    return ds"
@@ -114,7 +113,7 @@
     "                u'16 - CO2 Longwave IR 13.3 \\u03BCm': 16}\n",
     "\n",
     "region = Select(\n",
-    "    options=['Mesoscale-1', 'Mesoscale-2', 'CONUS'],\n",
+    "    options=['Mesoscale-1', 'Mesoscale-2', 'CONUS', 'PuertoRico', 'FullDisk'],\n",
     "    description='Region:',\n",
     ")\n",
     "\n",
@@ -153,7 +152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/Satellite_Data/solutions/data_url.py
+++ b/notebooks/Satellite_Data/solutions/data_url.py
@@ -9,8 +9,8 @@ channel = 8
 # https://thredds-test.unidata.ucar.edu/thredds/catalog/satellite/goes16/GOES16/Mesoscale-1/Channel08/20181113/catalog.html
 
 # Construct the data_url string
-data_url = ('https://thredds.ucar.edu/thredds/catalog/satellite'
-            f'/goes16/GOES16/{region}/Channel{channel:02d}/'
+data_url = ('https://thredds.ucar.edu/thredds/catalog/satellite/goes/east/products/'
+            f'CloudAndMoistureImagery/{region}/Channel{channel:02d}/'
             f'{image_date:%Y%m%d}/catalog.xml')
 
 # Print out your URL and verify it works!


### PR DESCRIPTION
Due to reorganization of thredds, links were updated in the satellite notebooks/solutions. Also two sectors were added (PR and FullDisk). 

Fixes #424.