### PR TITLE
Update Valpo agenda

### DIFF
--- a/events/valpo2019.md
+++ b/events/valpo2019.md
@@ -11,26 +11,27 @@ title:
 |  Time | Section                                      | Presenter   | Length |
 |-------|----------------------------------------------|-------------|--------|
 | 9:00 | Introductions and Overview | All | 0:10 |
+| 9:10 | Python Ecosystem | Zach | 0:20 |
+| 9:30 | [Introduction to Numpy](https://github.com/Unidata/python-workshop/blob/master/notebooks/NumPy/Numpy%20Basics.ipynb) | Ryan | 1:00 |
 | 10:30 | Break | N/A | 0:10 |
-| 10:40 | [Introduction to Numpy](https://github.com/Unidata/python-workshop/blob/master/notebooks/NumPy/Numpy%20Basics.ipynb) | Ryan | 1:00 |
-| 11:40 | Lunch | N/A | 1:15 |
-| 12:55 | [Introduction to Pandas](https://github.com/Unidata/python-workshop/blob/master/notebooks/Pandas/Pandas%20Introduction.ipynb) | Zach | 0:45 |
-| 13:40 | [Introduction to Xarray](https://github.com/Unidata/python-workshop/blob/master/notebooks/XArray/XArray%20Introduction.ipynb) | Ryan | 0:45 |
-| 14:25 | Break | N/A | 0:15 |
-| 14:40 | [Introduction to Matplotlib](https://github.com/Unidata/python-workshop/blob/master/notebooks/Matplotlib/Matplotlib%20Basics.ipynb) | Zach | 0:30 |
+| 10:40 | [Introduction to Pandas](https://github.com/Unidata/python-workshop/blob/master/notebooks/Pandas/Pandas%20Introduction.ipynb) | Zach | 1:15 |
+| 11:55 | Lunch | N/A | 1:15 |
+| 13:10 | [Introduction to Xarray](https://github.com/Unidata/python-workshop/blob/master/notebooks/XArray/XArray%20Introduction.ipynb) | Ryan | 0:45 |
+| 13:55 | [Introduction to Matplotlib](https://github.com/Unidata/python-workshop/blob/master/notebooks/Matplotlib/Matplotlib%20Basics.ipynb) | Zach | 1:00 |
+| 14:55 | Break | N/A | 0:15 |
 | 15:10 | [Introduction to MetPy](https://github.com/Unidata/python-workshop/blob/master/notebooks/Metpy_Introduction/Introduction%20to%20MetPy.ipynb) | Ryan | 0:45 |
-| 15:55 | [Introduction to siphon](https://github.com/Unidata/python-workshop/blob/master/notebooks/Siphon/Siphon%20Overview.ipynb) | Ryan | 0:30 |
-| 16:25 | End of Day |  |
+| 15:55 | [Introduction to siphon](https://github.com/Unidata/python-workshop/blob/master/notebooks/Siphon/Siphon%20Overview.ipynb) | Ryan | 0:20 |
+| 16:15 | End of Day |  |
 
 ## Day 2
 
 |  Time | Section                                      | Presenter   | Length |
 |-------|----------------------------------------------|-------------|--------|
-| 9:00 | [Pythonic Data Analysis](https://github.com/Unidata/python-workshop/blob/master/notebooks/Pythonic_Data_Analysis/Pythonic%20Data%20Analysis.ipynb) | Max | 1:30 |
+| 9:00 | [Pythonic Data Analysis](https://github.com/Unidata/python-workshop/blob/master/notebooks/Pythonic_Data_Analysis/Pythonic%20Data%20Analysis.ipynb) | Zach | 1:20 |
 | 10:20 | Break | N/A | 0:10 |
 | 10:30 | [Making Maps with Cartopy](https://github.com/Unidata/python-workshop/blob/master/notebooks/CartoPy/CartoPy.ipynb) | Ryan | 0:40 |
 | 11:10 | [Plotting SkewTs with MetPy](https://github.com/Unidata/python-workshop/blob/master/notebooks/Skew_T/SkewT_and_Hodograph.ipynb) | Ryan | 0:50 |
-| 12:00 | Lunch | NA | 1:15 |
+| 12:00 | Lunch | N/A | 1:15 |
 | 13:15 | [Working with Satellite Data](https://github.com/Unidata/python-workshop/blob/master/notebooks/Satellite_Data/Working%20with%20Satellite%20Data.ipynb) | Zach | 1:00 |
 | 14:15 | Break | N/A | 0:15 |
 | 14:30 | [Model Output](https://github.com/Unidata/python-workshop/blob/master/notebooks/Model_Output/Downloading%20model%20fields%20with%20NCSS.ipynb) | Zach | 0:40 |

--- a/events/valpo2019.md
+++ b/events/valpo2019.md
@@ -11,8 +11,6 @@ title:
 |  Time | Section                                      | Presenter   | Length |
 |-------|----------------------------------------------|-------------|--------|
 | 9:00 | Introductions and Overview | All | 0:10 |
-| 9:10 | [Conda](https://github.com/Unidata/python-workshop/blob/master/presentations/10_Minutes_to_Conda.pdf) | Ryan | 0:20 |
-| 9:30 | [Jupyter](https://github.com/Unidata/python-workshop/blob/master/notebooks/Jupyter_Notebooks/Jupyter%20Notebooks%20Introduction.ipynb) | Zach | 1:00 |
 | 10:30 | Break | N/A | 0:10 |
 | 10:40 | [Introduction to Numpy](https://github.com/Unidata/python-workshop/blob/master/notebooks/NumPy/Numpy%20Basics.ipynb) | Ryan | 1:00 |
 | 11:40 | Lunch | N/A | 1:15 |

--- a/index.md
+++ b/index.md
@@ -28,6 +28,7 @@ to get a feel for what's in the workshop.
   is an excellent primer on Python before diving into this workshop
 - Jake VanderPlas' excellent [Whirlwind Tour of Python](http://nbviewer.jupyter.org/github/jakevdp/WhirlwindTourOfPython/blob/master/Index.ipynb)
   is also a good place to look to get started
+- To learn more about conda and environments, please check out this [Carpentry-style tutorial](https://kaust-vislab.github.io/introduction-to-conda-for-data-scientists/)
 - Documentation for packages used:
   - [MetPy](https://unidata.github.io/MetPy/)
   - [Siphon](https://unidata.github.io/siphon/)

--- a/installation.md
+++ b/installation.md
@@ -64,3 +64,5 @@ on the Mac).
 * Run the command `conda env create` and wait for the installation to finish.
 * Run the command `conda activate unidata` to activate the unidata environment and
   verify that everything is ready.
+* For an in-depth tutorial on conda and environments, check out this 
+  [Carpentry-style tutorial](https://kaust-vislab.github.io/introduction-to-conda-for-data-scientists/).


### PR DESCRIPTION
Update the agenda for the Valpo workshop based on #421, #418, and #417. 

Closes #421. 

#417 can be closed once the notebooks are updated with appropriate timings.