### PR TITLE
Use indices to specify addition of data to a dataframe

### DIFF
--- a/notebooks/Pandas/Pandas Introduction.ipynb
+++ b/notebooks/Pandas/Pandas Introduction.ipynb
@@ -55,8 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pandas import Series\n",
-    "temperatures = Series([23, 20, 25, 18])\n",
+    "import pandas as pd\n",
+    "temperatures = pd.Series([23, 20, 25, 18])\n",
     "temperatures"
    ]
   },
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "temperatures = Series([23, 20, 25, 18], index=['TOP', 'OUN', 'DAL', 'DEN'])\n",
+    "temperatures = pd.Series([23, 20, 25, 18], index=['TOP', 'OUN', 'DAL', 'DEN'])\n",
     "temperatures"
    ]
   },
@@ -148,7 +148,7 @@
     "       'PHX': 11,\n",
     "       'DAL': 23}\n",
     "\n",
-    "dewpoints = Series(dps)\n",
+    "dewpoints = pd.Series(dps)\n",
     "dewpoints"
    ]
   },
@@ -263,13 +263,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pandas import DataFrame\n",
-    "\n",
     "data = {'station': ['TOP', 'OUN', 'DEN', 'DAL'],\n",
     "        'temperature': [23, 20, 25, 18],\n",
     "        'dewpoint': [14, 18, 9, 23]}\n",
     "\n",
-    "df = DataFrame(data)\n",
+    "df = pd.DataFrame(data)\n",
     "df"
    ]
   },
@@ -364,7 +362,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['pressure'] = Series([1010,1000,998,1018], index=['DEN','TOP','DAL','OUN'])\n",
+    "df['pressure'] = pd.Series([1010,1000,998,1018], index=['DEN','TOP','DAL','OUN'])\n",
     "df"
    ]
   },
@@ -474,15 +472,6 @@
     "<a name=\"loading\"></a>\n",
     "## Loading Data in Pandas\n",
     "The real power of pandas is in manupulating and summarizing large sets of tabular data. To do that, we'll need a large set of tabular data. We've included a file in this directory called `JAN17_CO_ASOS.txt` that has all of the ASOS observations for several stations in Colorado for January of 2017. It's a few hundred thousand rows of data in a tab delimited format. Let's load it into Pandas."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd"
    ]
   },
   {

--- a/notebooks/Pandas/Pandas Introduction.ipynb
+++ b/notebooks/Pandas/Pandas Introduction.ipynb
@@ -355,6 +355,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can also add data and order it by providing index values. Note that the next cell contains data that's \"out of order\" compared to the dataframe shown above. However, by providing the index that corresponds to each value, the data is organized correctly into the dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['pressure'] = Series([1010,1000,998,1018], index=['DEN','TOP','DAL','OUN'])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now let's get a row from the dataframe instead of a column."
    ]
   },
@@ -875,7 +892,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/Pandas/solutions/make_series.py
+++ b/notebooks/Pandas/solutions/make_series.py
@@ -1,4 +1,4 @@
-pressures = Series([1012.1, 1010.6, 1008.8, 1011.2], index=['TOP', 'OUN', 'DEN', 'DAL'])
+pressures = pd.Series([1012.1, 1010.6, 1008.8, 1011.2], index=['TOP', 'OUN', 'DEN', 'DAL'])
 pressures.name = 'pressure'
 pressures.index.name = 'station'
 print(pressures[dewpoints < 15])


### PR DESCRIPTION
Adds an example in the Pandas notebook of how to use indices of a data frame to specify the location of data within a new column.

Closes #415, once #428 is merged too.