### PR TITLE
Update to NumPy notebooks for slicing/indexing

### DIFF
--- a/notebooks/NumPy/Intermediate NumPy.ipynb
+++ b/notebooks/NumPy/Intermediate NumPy.ipynb
@@ -24,8 +24,8 @@
     "\n",
     "## Overview:\n",
     "\n",
-    "* **Teaching:** 20 minutes\n",
-    "* **Exercises:** 25 minutes\n",
+    "* **Teaching:** 15 minutes\n",
+    "* **Exercises:** 15 minutes\n",
     "\n",
     "### Questions\n",
     "1. How do we work with the multiple dimensions in a NumPy Array?\n",
@@ -33,7 +33,7 @@
     "1. How can we sort an array?\n",
     "\n",
     "### Objectives\n",
-    "1. <a href=\"#indexing\">Index and slice arrays</a>\n",
+    "1. <a href=\"#indexing\">Using axes to slice arrays</a>\n",
     "1. <a href=\"#boolean\">Index arrays using true and false</a>\n",
     "1. <a href=\"#integers\">Index arrays using arrays of indices</a>"
    ]
@@ -47,9 +47,11 @@
    },
    "source": [
     "<a name=\"indexing\"></a>\n",
-    "## 1. Index and slice arrays\n",
+    "## 1. Using axes to slice arrays\n",
     "\n",
-    "Indexing is how we pull individual data items out of an array. Slicing extends this process to pulling out a regular set of the items."
+    "The solution to the last exercise in the Numpy Basics notebook introduces an important concept when working with NumPy: the axis. This indicates the particular dimension along which a function should operate (provided the function does something taking multiple values and converts to a single value). \n",
+    "\n",
+    "Let's look at a concrete example with `sum`:"
    ]
   },
   {
@@ -73,286 +75,7 @@
    "outputs": [],
    "source": [
     "# Create an array for testing\n",
-    "a = np.arange(12).reshape(3, 4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "a"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Indexing in Python is 0-based, so the command below looks for the 2nd item along the first dimension (row) and the 3rd along the second dimension (column)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "a[1, 2]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Can also just index on one dimension"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "a[2]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Negative indices are also allowed, which permit indexing relative to the end of the array."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "a[0, -1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Slicing syntax is written as `start:stop[:step]`, where all numbers are optional.\n",
-    "- defaults: \n",
-    "  - start = 0\n",
-    "  - end = len(dim)\n",
-    "  - step = 1\n",
-    "- The second colon is also optional if no step is used.\n",
-    "\n",
-    "It should be noted that end represents one past the last item; one can also think of it as a half open interval: `[start, end)`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Get the 2nd and 3rd rows\n",
-    "a[1:3]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# All rows and 3rd column\n",
-    "a[:, 2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# ... can be used to replace one or more full slices\n",
-    "a[..., 2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Slice every other row\n",
-    "a[::2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# You can also slice using negative indices\n",
-    "a[:, :-1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-success\">\n",
-    "    <b>EXERCISE</b>:\n",
-    "     <ul>\n",
-    "      <li>The code below calculates a two point average using a Python list and loop. Convert it do obtain the same results using NumPy slicing</li>\n",
-    "    <li>Bonus points: Can you extend the NumPy version to do a 3 point (running) average?</li>\n",
-    "    </ul>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = [1, 3, 5, 7, 9, 11]\n",
-    "out = []\n",
-    "\n",
-    "# Look carefully at the loop. Think carefully about the sequence of values\n",
-    "# that data[i] takes--is there some way to get those values as a numpy slice?\n",
-    "# What about for data[i + 1]?\n",
-    "for i in range(len(data) - 1):\n",
-    "    out.append((data[i] + data[i + 1]) / 2)\n",
-    "\n",
-    "print(out)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<button data-toggle=\"collapse\" data-target=\"#sol1\" class='btn btn-primary'>View Solution</button>\n",
-    "<div id=\"sol1\" class=\"collapse\">\n",
-    "<code><pre>\n",
-    "data = np.array([1, 3, 5, 7, 9, 11])\n",
-    "out = (data[:-1] + data[1:]) / 2\n",
-    "print(out)\n",
-    "</pre></code>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<button data-toggle=\"collapse\" data-target=\"#sol2\" class='btn btn-primary'>View Bonus Solution</button>\n",
-    "<div id=\"sol2\" class=\"collapse\">\n",
-    "<code><pre>\n",
-    "data = np.array([1, 3, 5, 7, 9, 11])\n",
-    "out = (data[2:] + data[1:-1] + data[:-2]) / 3\n",
-    "print(out)\n",
-    "</pre></code>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-success\">\n",
-    "    <b>EXERCISE</b>:\n",
-    "     <ul>\n",
-    "      <li>Given the array of data below, calculate the total of each of the columns (i.e. add each of the three rows together):</li>\n",
-    "    </ul>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = np.arange(12).reshape(3, 4)\n",
-    "\n",
-    "# total = ?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<button data-toggle=\"collapse\" data-target=\"#sol3\" class='btn btn-primary'>View Solution</button>\n",
-    "<div id=\"sol3\" class=\"collapse\">\n",
-    "<code><pre>\n",
-    "print(data[0] + data[1] + data[2])\n",
-    "\n",
-    "\\# Or we can use numpy's sum and use the \"axis\" argument\n",
-    "print(np.sum(data, axis=0))\n",
-    "</pre></code>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The solution to the last exercise introduces an important concept when working with NumPy: the axis. This indicates the particular dimension along which a function should operate (provided the function does something taking multiple values and converts to a single value). \n",
-    "\n",
-    "Let's look at a concrete example with `sum`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "a = np.arange(12).reshape(3, 4)\n",
     "a"
    ]
   },
@@ -783,7 +506,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/NumPy/Numpy Basics.ipynb
+++ b/notebooks/NumPy/Numpy Basics.ipynb
@@ -24,7 +24,7 @@
     "## Overview:\n",
     "\n",
     "* **Teaching:** 20 minutes\n",
-    "* **Exercises:** 10 minutes\n",
+    "* **Exercises:** 25 minutes\n",
     "\n",
     "### Questions\n",
     "1. What are arrays?\n",
@@ -740,6 +740,103 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-success\">\n",
+    "    <b>EXERCISE</b>:\n",
+    "     <ul>\n",
+    "      <li>The code below calculates a two point average using a Python list and loop. Convert it do obtain the same results using NumPy slicing</li>\n",
+    "    <li>Bonus points: Can you extend the NumPy version to do a 3 point (running) average?</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [1, 3, 5, 7, 9, 11]\n",
+    "out = []\n",
+    "\n",
+    "# Look carefully at the loop. Think carefully about the sequence of values\n",
+    "# that data[i] takes--is there some way to get those values as a numpy slice?\n",
+    "# What about for data[i + 1]?\n",
+    "for i in range(len(data) - 1):\n",
+    "    out.append((data[i] + data[i + 1]) / 2)\n",
+    "\n",
+    "print(out)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<button data-toggle=\"collapse\" data-target=\"#sol1\" class='btn btn-primary'>View Solution</button>\n",
+    "<div id=\"sol1\" class=\"collapse\">\n",
+    "<code><pre>\n",
+    "data = np.array([1, 3, 5, 7, 9, 11])\n",
+    "out = (data[:-1] + data[1:]) / 2\n",
+    "print(out)\n",
+    "</pre></code>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<button data-toggle=\"collapse\" data-target=\"#sol2\" class='btn btn-primary'>View Bonus Solution</button>\n",
+    "<div id=\"sol2\" class=\"collapse\">\n",
+    "<code><pre>\n",
+    "data = np.array([1, 3, 5, 7, 9, 11])\n",
+    "out = (data[2:] + data[1:-1] + data[:-2]) / 3\n",
+    "print(out)\n",
+    "</pre></code>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-success\">\n",
+    "    <b>EXERCISE</b>:\n",
+    "     <ul>\n",
+    "      <li>Given the array of data below, calculate the total of each of the columns (i.e. add each of the three rows together):</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.arange(12).reshape(3, 4)\n",
+    "\n",
+    "# total = ?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<button data-toggle=\"collapse\" data-target=\"#sol3\" class='btn btn-primary'>View Solution</button>\n",
+    "<div id=\"sol3\" class=\"collapse\">\n",
+    "<code><pre>\n",
+    "print(data[0] + data[1] + data[2])\n",
+    "\n",
+    "\\# Or we can use numpy's sum and use the \"axis\" argument\n",
+    "print(np.sum(data, axis=0))\n",
+    "</pre></code>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Resources\n",
     "\n",
     "The goal of this tutorial is to provide an overview of the use of the NumPy library. It tries to hit all of the important parts, but it is by no means comprehensive. For more information, try looking at the:\n",
@@ -765,7 +862,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Eliminated overlap in notebooks on slicing/indexing. Basics now contains all indexing and slicing examples, other than using axes to conduct operations. The intermediate notebook was chopped down considerably.

Closes #369.