### PR TITLE
Cleanup netCDF4 import methods

### DIFF
--- a/notebooks/Bonus/netCDF-Writing.ipynb
+++ b/notebooks/Bonus/netCDF-Writing.ipynb
@@ -45,7 +45,7 @@
    },
    "outputs": [],
    "source": [
-    "import netCDF4     # Note: python is case-sensitive!\n",
+    "from netCDF4 import Dataset    # Note: python is case-sensitive!\n",
     "import numpy as np"
    ]
   },
@@ -91,7 +91,7 @@
    "source": [
     "try: ncfile.close()  # just to be safe, make sure dataset is not already open.\n",
     "except: pass\n",
-    "ncfile = netCDF4.Dataset('../../data/new.nc',mode='w',format='NETCDF4_CLASSIC') \n",
+    "ncfile = Dataset('../../data/new.nc',mode='w',format='NETCDF4_CLASSIC') \n",
     "print(ncfile)"
    ]
   },
@@ -593,7 +593,7 @@
    },
    "outputs": [],
    "source": [
-    "ncfile = netCDF4.Dataset('../../data/new2.nc','w',format='NETCDF4')\n",
+    "ncfile = Dataset('../../data/new2.nc','w',format='NETCDF4')\n",
     "print(ncfile)"
    ]
   },
@@ -977,7 +977,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Only two notebooks use the netCDF4 module (likely due to shift to xarray since this issue was filed). This cleans up one notebook to be consistent with the Case Study notebook to use `from netCDF4 import` syntax.

Closes #107.