### PR TITLE
Updates for the isentropic notebook and solutions

### DIFF
--- a/notebooks/MetPy_Advanced/Isentropic Analysis.ipynb
+++ b/notebooks/MetPy_Advanced/Isentropic Analysis.ipynb
@@ -241,16 +241,16 @@
    "source": [
     "lat = dat.metpy.y\n",
     "lon = dat.metpy.x\n",
-    "press = ds['isobaric']\n",
-    "temperature = ds['Temperature_isobaric'][0]\n",
+    "press = ds.metpy.parse_cf('isobaric')\n",
+    "temperature = ds.metpy.parse_cf('Temperature_isobaric')[0]\n",
     "\n",
     "# Need to adjust units on humidity because '%' causes problems\n",
     "ds['Relative_humidity_isobaric'].attrs['units'] = 'percent'\n",
     "\n",
-    "rh = ds['Relative_humidity_isobaric'][0]\n",
-    "height = ds['Geopotential_height_isobaric'][0]\n",
-    "u = ds['u-component_of_wind_isobaric'][0]\n",
-    "v = ds['v-component_of_wind_isobaric'][0]\n",
+    "rh = ds.metpy.parse_cf('Relative_humidity_isobaric')[0]\n",
+    "height = ds.metpy.parse_cf('Geopotential_height_isobaric')[0]\n",
+    "u = ds.metpy.parse_cf('u-component_of_wind_isobaric')[0]\n",
+    "v = ds.metpy.parse_cf('v-component_of_wind_isobaric')[0]\n",
     "\n",
     "# Due to a different number of vertical levels find where they are common\n",
     "lev_hght = temperature.coords['isobaric4'] * units.Pa\n",
@@ -325,14 +325,13 @@
     "# Create a plot and basic map projection\n",
     "fig = plt.figure(figsize=(14, 8))\n",
     "ax = fig.add_subplot(1, 1, 1, projection=ccrs.LambertConformal(central_longitude=-100))\n",
-    "ax.coastlines()\n",
     "\n",
     "# Contour the pressure values for the isentropic level. We keep the handle\n",
     "# for the contour so that we can have matplotlib label the contours\n",
     "levels = np.arange(300, 1000, 25)\n",
     "cntr = ax.contour(lon, lat, isen_press, transform=data_proj,\n",
     "                  colors='black', levels=levels)\n",
-    "ax.clabel(cntr, fmt='%d')\n",
+    "cntr.clabel(fmt='%d')\n",
     "\n",
     "# Set up slices to subset the wind barbs--the slices below are the same as `::5`\n",
     "# We put these here so that it's easy to change and keep all of the ones below matched\n",
@@ -342,7 +341,7 @@
     "ax.barbs(lon[lon_slice], lat[lat_slice],\n",
     "         isen_u[lat_slice, lon_slice].to('knots').magnitude,\n",
     "         isen_v[lat_slice, lon_slice].to('knots').magnitude,\n",
-    "         transform=ccrs.PlateCarree(), zorder=2)\n",
+    "         transform=data_proj, zorder=2)\n",
     "\n",
     "ax.add_feature(cfeature.LAND)\n",
     "ax.add_feature(cfeature.OCEAN)\n",
@@ -350,7 +349,7 @@
     "ax.add_feature(cfeature.BORDERS, linewidth=2)\n",
     "ax.add_feature(cfeature.STATES, linestyle=':')\n",
     "\n",
-    "ax.set_extent((-120, -70, 25, 55), crs=ccrs.PlateCarree())"
+    "ax.set_extent((-120, -70, 25, 55), crs=data_proj)"
    ]
   },
   {
@@ -397,19 +396,18 @@
     "# Create Plot -- same as before\n",
     "fig = plt.figure(figsize=(14, 8))\n",
     "ax = fig.add_subplot(1, 1, 1, projection=ccrs.LambertConformal(central_longitude=-100))\n",
-    "ax.coastlines()\n",
     "\n",
     "levels = np.arange(300, 1000, 25)\n",
-    "cntr = ax.contour(lon, lat, isen_press, transform=ccrs.PlateCarree(),\n",
+    "cntr = ax.contour(lon, lat, isen_press, transform=data_proj,\n",
     "                  colors='black', levels=levels)\n",
-    "ax.clabel(cntr, fmt='%d')\n",
+    "cntr.clabel(fmt='%d')\n",
     "\n",
     "lon_slice = slice(None, None, 8)\n",
     "lat_slice = slice(None, None, 8)\n",
     "ax.barbs(lon[lon_slice], lat[lat_slice],\n",
     "         isen_u[lat_slice, lon_slice].to('knots').magnitude,\n",
     "         isen_v[lat_slice, lon_slice].to('knots').magnitude,\n",
-    "         transform=ccrs.PlateCarree(), zorder=2)\n",
+    "         transform=data_proj, zorder=2)\n",
     "\n",
     "#\n",
     "# YOUR CODE: Contour/Contourf the mixing ratio values\n",
@@ -422,7 +420,7 @@
     "ax.add_feature(cfeature.BORDERS, linewidth=2)\n",
     "ax.add_feature(cfeature.STATES, linestyle=':')\n",
     "\n",
-    "ax.set_extent((-120, -70, 25, 55), crs=ccrs.PlateCarree())"
+    "ax.set_extent((-120, -70, 25, 55), crs=data_proj)"
    ]
   },
   {
@@ -551,13 +549,20 @@
    "source": [
     "# %load solutions/lift.py\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:unidata]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-unidata-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/MetPy_Advanced/solutions/lift.py
+++ b/notebooks/MetPy_Advanced/solutions/lift.py
@@ -1,10 +1,10 @@
 fig = plt.figure(figsize=(14, 8))
 ax = fig.add_subplot(1, 1, 1, projection=ccrs.LambertConformal(central_longitude=-100))
-ax.coastlines()
+ax.add_feature(cfeature.COASTLINE)
 
 levels = np.arange(300, 1000, 25)
-cntr = ax.contour(lon, lat, isen_press, transform=ccrs.PlateCarree(), colors='black', levels=levels)
-ax.clabel(cntr, fmt='%d')
+cntr = ax.contour(lon, lat, isen_press, transform=data_proj, colors='black', levels=levels)
+cntr.clabel(fmt='%d')
 
 
 lon_slice = slice(None, None, 5)
@@ -12,13 +12,13 @@ lat_slice = slice(None, None, 5)
 ax.barbs(lon[lon_slice], lat[lat_slice],
          isen_u[lon_slice, lat_slice].to('knots').magnitude,
          isen_v[lon_slice, lat_slice].to('knots').magnitude,
-         transform=ccrs.PlateCarree(), zorder=2)
+         transform=data_proj, zorder=2)
 
 
 levels = np.arange(-6, 7)
 cs = ax.contourf(lon, lat, lift.to('microbar/s'), levels=levels, cmap='RdBu',
-                 transform=ccrs.PlateCarree(), extend='both')
+                 transform=data_proj, extend='both')
 plt.colorbar(cs)
 
 
-ax.set_extent((-120, -70, 25, 55), crs=ccrs.PlateCarree())
+ax.set_extent((-120, -70, 25, 55), crs=data_proj)

--- a/notebooks/MetPy_Advanced/solutions/mixing.py
+++ b/notebooks/MetPy_Advanced/solutions/mixing.py
@@ -26,13 +26,11 @@ isen_v = isen_v.squeeze()
 # Create Plot -- same as before
 fig = plt.figure(figsize=(14, 8))
 ax = fig.add_subplot(1, 1, 1, projection=ccrs.LambertConformal(central_longitude=-100))
-ax.coastlines()
-
 
 levels = np.arange(300, 1000, 25)
-cntr = ax.contour(lon, lat, isen_press, transform=ccrs.PlateCarree(),
+cntr = ax.contour(lon, lat, isen_press, transform=data_proj,
                   colors='black', levels=levels)
-ax.clabel(cntr, fmt='%d')
+cntr.clabel(fmt='%d')
 
 
 lon_slice = slice(None, None, 8)
@@ -40,12 +38,12 @@ lat_slice = slice(None, None, 8)
 ax.barbs(lon[lon_slice], lat[lat_slice],
          isen_u[lat_slice, lon_slice].to('knots').magnitude,
          isen_v[lat_slice, lon_slice].to('knots').magnitude,
-         transform=ccrs.PlateCarree(), zorder=2)
+         transform=data_proj, zorder=2)
 
 
 # Contourf the mixing ratio values
 mixing_levels = [0.001, 0.002, 0.004, 0.006, 0.010, 0.012, 0.014, 0.016, 0.020]
-ax.contourf(lon, lat, isen_mixing, transform=ccrs.PlateCarree(),
+ax.contourf(lon, lat, isen_mixing, transform=data_proj,
             levels=mixing_levels, cmap='YlGn')
 
 
@@ -56,4 +54,4 @@ ax.add_feature(cfeature.BORDERS, linewidth=2)
 ax.add_feature(cfeature.STATES, linestyle=':')
 
 
-ax.set_extent((-120, -70, 25, 55), crs=ccrs.PlateCarree())
+ax.set_extent((-120, -70, 25, 55), crs=data_proj)


### PR DESCRIPTION
Addresses 4/5 issues in #389, including removing multiple coastline calls, cleaning up contour labeling, calling `parse_cf` to read in variables, and using `data_proj` to replace hard-coded CRSs. The only remaining issue is removing hard-coding of "isentropic". Clarification on how to handle that would be appreciated if that can be handled in this PR as well.