### PR TITLE
MNT: Cleanup CartoPy example

### DIFF
--- a/notebooks/CartoPy/CartoPy.ipynb
+++ b/notebooks/CartoPy/CartoPy.ipynb
@@ -376,7 +376,10 @@
     "v = np.full((5, 5), 10) + 10 * np.arange(5)\n",
     "u = np.zeros_like(v)\n",
     "speed = wind_speed(u, v)\n",
-    "x, y = np.meshgrid(np.linspace(-120, -60, 5), np.linspace(25, 50, 5))\n",
+    "\n",
+    "# Create arrays of longitude and latitude\n",
+    "x = np.linspace(-120, -60, 5)\n",
+    "y = np.linspace(30, 55, 5)\n",
     "\n",
     "# Plot as normal\n",
     "fig = plt.figure(figsize=(10, 8))\n",
@@ -388,11 +391,6 @@
     "# Plot wind barbs--CartoPy handles reprojecting the vectors properly for the\n",
     "# coordinate system\n",
     "ax.barbs(x, y, u, v, transform=ccrs.PlateCarree(), color='tab:blue')\n",
-    "\n",
-    "# Contour the wind speed\n",
-    "contours = np.arange(5, 50, 10)\n",
-    "ax.contour(x, y, speed, contours, colors='black',\n",
-    "           linestyles='--', transform=ccrs.PlateCarree())\n",
     "\n",
     "ax.set_extent([-130, -60, 20, 55])"
    ]

--- a/notebooks/CartoPy/CartoPy.ipynb
+++ b/notebooks/CartoPy/CartoPy.ipynb
@@ -79,6 +79,7 @@
     "\n",
     "# Importing CartoPy\n",
     "import cartopy.crs as ccrs\n",
+    "import cartopy.feature as cfeature\n",
     "import matplotlib.pyplot as plt"
    ]
   },
@@ -173,9 +174,7 @@
     "\n",
     "ax.stock_img()\n",
     "\n",
-    "# Specifies the detail level of the map.\n",
-    "# Options are '110m' (default), '50m', and '10m'\n",
-    "ax.coastlines(resolution='50m')\n",
+    "ax.add_feature(cfeature.COASTLINE)\n",
     "\n",
     "ax.set_extent([-130, -60, 20, 55])"
    ]
@@ -201,9 +200,6 @@
    },
    "outputs": [],
    "source": [
-    "# import cartopy's collection of map features\n",
-    "import cartopy.feature as cfeature\n",
-    "\n",
     "fig = plt.figure(figsize=(10, 8))\n",
     "ax = fig.add_subplot(1, 1, 1, projection=ccrs.LambertConformal())\n",
     "\n",
@@ -377,7 +373,7 @@
     "from metpy.calc import wind_speed\n",
     "\n",
     "# Note that all of these winds have u = 0 -> south wind\n",
-    "v = np.full((5, 5), 10, dtype=np.float64) + 10 * np.arange(5)\n",
+    "v = np.full((5, 5), 10) + 10 * np.arange(5)\n",
     "u = np.zeros_like(v)\n",
     "speed = wind_speed(u, v)\n",
     "x, y = np.meshgrid(np.linspace(-120, -60, 5), np.linspace(25, 50, 5))\n",
@@ -387,7 +383,7 @@
     "ax = fig.add_subplot(1, 1, 1, projection=ccrs.LambertConformal())\n",
     "\n",
     "ax.add_feature(cfeature.COASTLINE)\n",
-    "ax.add_feature(cfeature.BORDERS, linewidth=2)\n",
+    "ax.add_feature(cfeature.BORDERS)\n",
     "\n",
     "# Plot wind barbs--CartoPy handles reprojecting the vectors properly for the\n",
     "# coordinate system\n",


### PR DESCRIPTION
 - Remove use of `ax.coastlines`
 - Simplify the wind barb example a little

Example could maybe be simplified more. Most confusing part to participants is probably the synthetic data creation, but not sure how to get around that.